### PR TITLE
Fix deprecation warnings about alias_method_chain

### DIFF
--- a/lib/postgres_ext/active_record/5.0/relation/predicate_builder/array_handler.rb
+++ b/lib/postgres_ext/active_record/5.0/relation/predicate_builder/array_handler.rb
@@ -1,38 +1,22 @@
 require 'active_record/relation/predicate_builder'
 require 'active_record/relation/predicate_builder/array_handler'
 
-require 'active_support/concern'
-
-module ActiveRecord
-  class PredicateBuilder
-    module ArrayHandlerPatch
-      extend ActiveSupport::Concern
-
-      included do
-        def call_with_feature(attribute, value)
-          column = case attribute.try(:relation)
-                   when Arel::Nodes::TableAlias, NilClass
-                   else
-                     cache = ActiveRecord::Base.connection.schema_cache
-                     if cache.data_source_exists? attribute.relation.name
-                       cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
-                     end
-                   end
-          if column && column.respond_to?(:array) && column.array
-            attribute.eq(value)
-          else
-            call_without_feature(attribute, value)
-          end
-        end
-
-        alias_method_chain(:call, :feature)
-      end
-
-      module ClassMethods
-
-      end
+module ArrayHandlerPatch
+  def call(attribute, value)
+    column = case attribute.try(:relation)
+             when Arel::Nodes::TableAlias, NilClass
+             else
+               cache = ActiveRecord::Base.connection.schema_cache
+               if cache.data_source_exists? attribute.relation.name
+                 cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
+               end
+             end
+    if column && column.respond_to?(:array) && column.array
+      attribute.eq(value)
+    else
+      super(attribute, value)
     end
   end
 end
 
-ActiveRecord::PredicateBuilder::ArrayHandler.send(:include, ActiveRecord::PredicateBuilder::ArrayHandlerPatch)
+ActiveRecord::PredicateBuilder::ArrayHandler.send(:prepend, ArrayHandlerPatch)

--- a/lib/postgres_ext/active_record/relation.rb
+++ b/lib/postgres_ext/active_record/relation.rb
@@ -5,6 +5,8 @@ gdep_5_0 = Gem::Dependency.new('activerecord', '~> 5.0.0')
 ar_5_0_version_cutoff = gdep_5_0.matching_specs.sort_by(&:version).last
 
 require 'postgres_ext/active_record/relation/merger'
+require 'postgres_ext/active_record/relation/query_methods/with_chain'
+require 'postgres_ext/active_record/relation/query_methods/where_chain'
 require 'postgres_ext/active_record/relation/query_methods'
 
 if ar_5_0_version_cutoff

--- a/lib/postgres_ext/active_record/relation/query_methods.rb
+++ b/lib/postgres_ext/active_record/relation/query_methods.rb
@@ -1,140 +1,5 @@
 module ActiveRecord
   module QueryMethods
-    class WhereChain
-      def overlap(opts, *rest)
-        substitute_comparisons(opts, rest, Arel::Nodes::Overlap, 'overlap')
-      end
-
-      def contained_within(opts, *rest)
-        substitute_comparisons(opts, rest, Arel::Nodes::ContainedWithin, 'contained_within')
-      end
-
-      def contained_within_or_equals(opts, *rest)
-        substitute_comparisons(opts, rest, Arel::Nodes::ContainedWithinEquals, 'contained_within_or_equals')
-      end
-
-      def contains(opts, *rest)
-        build_where_chain(opts, rest) do |rel|
-          case rel
-          when Arel::Nodes::In, Arel::Nodes::Equality
-            column = left_column(rel) || column_from_association(rel)
-            equality_for_hstore(rel) if column.type == :hstore
-
-            if column.type == :hstore
-              Arel::Nodes::ContainsHStore.new(rel.left, rel.right)
-            elsif column.respond_to?(:array) && column.array
-              Arel::Nodes::ContainsArray.new(rel.left, rel.right)
-            else
-              Arel::Nodes::ContainsINet.new(rel.left, rel.right)
-            end
-          else
-            raise ArgumentError, "Invalid argument for .where.overlap(), got #{rel.class}"
-          end
-        end
-      end
-
-      def contained_in_array(opts, *rest)
-        build_where_chain(opts, rest) do |rel|
-          case rel
-          when Arel::Nodes::In, Arel::Nodes::Equality
-            column = left_column(rel) || column_from_association(rel)
-            equality_for_hstore(rel) if column.type == :hstore
-
-            if column.type == :hstore
-              Arel::Nodes::ContainedInHStore.new(rel.left, rel.right)
-            elsif column.respond_to?(:array) && column.array
-              Arel::Nodes::ContainedInArray.new(rel.left, rel.right)
-            else
-              Arel::Nodes::ContainsINet.new(rel.left, rel.right)
-            end
-          else
-            raise ArgumentError, "Invalid argument for .where.overlap(), got #{rel.class}"
-          end
-        end
-      end
-
-      def contains_or_equals(opts, *rest)
-        substitute_comparisons(opts, rest, Arel::Nodes::ContainsEquals, 'contains_or_equals')
-      end
-
-      def any(opts, *rest)
-        equality_to_function('ANY', opts, rest)
-      end
-
-      def all(opts, *rest)
-        equality_to_function('ALL', opts, rest)
-      end
-
-      private
-
-      def find_column(col, rel)
-        col.name == rel.left.name.to_s || col.name == rel.left.relation.name.to_s
-      end
-
-      def column_from_association(rel)
-        if assoc = assoc_from_related_table(rel)
-          column = assoc.klass.columns.find { |col| find_column(col, rel) }
-        end
-      end
-
-      def equality_for_hstore(rel)
-        new_right_name = rel.left.name.to_s
-        if rel.right.respond_to?(:val)
-          return if rel.right.val.is_a?(Hash)
-          rel.right = Arel::Nodes.build_quoted({new_right_name => rel.right.val},
-                                               rel.left)
-        else
-          return if rel.right.is_a?(Hash)
-          rel.right = {new_right_name => rel.right }
-        end
-
-        rel.left.name = rel.left.relation.name.to_sym
-        rel.left.relation.name = @scope.klass.table_name
-      end
-
-      def assoc_from_related_table(rel)
-        @scope.klass.reflect_on_association(rel.left.relation.name.to_sym) ||
-          @scope.klass.reflect_on_association(rel.left.relation.name.singularize.to_sym)
-      end
-
-      def substitute_comparisons(opts, rest, arel_node_class, method)
-        build_where_chain(opts, rest) do |rel|
-          case rel
-          when Arel::Nodes::In, Arel::Nodes::Equality
-            arel_node_class.new(rel.left, rel.right)
-          else
-            raise ArgumentError, "Invalid argument for .where.#{method}(), got #{rel.class}"
-          end
-        end
-      end
-
-      def equality_to_function(function_name, opts, rest)
-        build_where_chain(opts, rest) do |rel|
-          case rel
-          when Arel::Nodes::Equality
-            Arel::Nodes::Equality.new(rel.right, Arel::Nodes::NamedFunction.new(function_name, [rel.left]))
-          else
-            raise ArgumentError, "Invalid argument for .where.#{function_name.downcase}(), got #{rel.class}"
-          end
-        end
-      end
-    end
-
-    # WithChain objects act as placeholder for queries in which #with does not have any parameter.
-    # In this case, #with must be chained with #recursive to return a new relation.
-    class WithChain
-      def initialize(scope)
-        @scope = scope
-      end
-
-      # Returns a new relation expressing WITH RECURSIVE
-      def recursive(*args)
-        @scope.with_values += args
-        @scope.recursive_value = true
-        @scope
-      end
-    end
-
     [:with].each do |name|
       class_eval <<-CODE, __FILE__, __LINE__ + 1
        def #{name}_values                   # def select_values
@@ -187,16 +52,6 @@ module ActiveRecord
     def ranked!(value)
       self.rank_value = value
       self
-    end
-
-    def build_arel_with_extensions
-      arel = build_arel_without_extensions
-
-      build_with(arel)
-
-      build_rank(arel, rank_value) if rank_value
-
-      arel
     end
 
     def build_with(arel)
@@ -254,7 +109,19 @@ module ActiveRecord
         end
       end
     end
-
-    alias_method_chain :build_arel, :extensions
   end
 end
+
+module RelationPrepend
+  def build_arel
+    arel = super
+
+    build_with(arel)
+
+    build_rank(arel, rank_value) if rank_value
+
+    arel
+  end
+end
+
+ActiveRecord::Relation.prepend(RelationPrepend)

--- a/lib/postgres_ext/active_record/relation/query_methods/where_chain.rb
+++ b/lib/postgres_ext/active_record/relation/query_methods/where_chain.rb
@@ -1,0 +1,124 @@
+module ActiveRecord
+  module QueryMethods
+    class WhereChain
+      def overlap(opts, *rest)
+        substitute_comparisons(opts, rest, Arel::Nodes::Overlap, 'overlap')
+      end
+
+      def contained_within(opts, *rest)
+        substitute_comparisons(opts, rest, Arel::Nodes::ContainedWithin, 'contained_within')
+      end
+
+      def contained_within_or_equals(opts, *rest)
+        substitute_comparisons(opts, rest, Arel::Nodes::ContainedWithinEquals, 'contained_within_or_equals')
+      end
+
+      def contains(opts, *rest)
+        build_where_chain(opts, rest) do |rel|
+          case rel
+          when Arel::Nodes::In, Arel::Nodes::Equality
+            column = left_column(rel) || column_from_association(rel)
+            equality_for_hstore(rel) if column.type == :hstore
+
+            if column.type == :hstore
+              Arel::Nodes::ContainsHStore.new(rel.left, rel.right)
+            elsif column.respond_to?(:array) && column.array
+              Arel::Nodes::ContainsArray.new(rel.left, rel.right)
+            else
+              Arel::Nodes::ContainsINet.new(rel.left, rel.right)
+            end
+          else
+            raise ArgumentError, "Invalid argument for .where.overlap(), got #{rel.class}"
+          end
+        end
+      end
+
+      def contained_in_array(opts, *rest)
+        build_where_chain(opts, rest) do |rel|
+          case rel
+          when Arel::Nodes::In, Arel::Nodes::Equality
+            column = left_column(rel) || column_from_association(rel)
+            equality_for_hstore(rel) if column.type == :hstore
+
+            if column.type == :hstore
+              Arel::Nodes::ContainedInHStore.new(rel.left, rel.right)
+            elsif column.respond_to?(:array) && column.array
+              Arel::Nodes::ContainedInArray.new(rel.left, rel.right)
+            else
+              Arel::Nodes::ContainsINet.new(rel.left, rel.right)
+            end
+          else
+            raise ArgumentError, "Invalid argument for .where.overlap(), got #{rel.class}"
+          end
+        end
+      end
+
+      def contains_or_equals(opts, *rest)
+        substitute_comparisons(opts, rest, Arel::Nodes::ContainsEquals, 'contains_or_equals')
+      end
+
+      def any(opts, *rest)
+        equality_to_function('ANY', opts, rest)
+      end
+
+      def all(opts, *rest)
+        equality_to_function('ALL', opts, rest)
+      end
+
+      private
+
+      def find_column(col, rel)
+        col.name == rel.left.name.to_s || col.name == rel.left.relation.name.to_s
+      end
+
+      def column_from_association(rel)
+        if assoc = assoc_from_related_table(rel)
+          column = assoc.klass.columns.find { |col| find_column(col, rel) }
+        end
+      end
+
+      def equality_for_hstore(rel)
+        new_right_name = rel.left.name.to_s
+        if rel.right.respond_to?(:val)
+          return if rel.right.val.is_a?(Hash)
+          rel.right = Arel::Nodes.build_quoted({new_right_name => rel.right.val},
+                                               rel.left)
+        else
+          return if rel.right.is_a?(Hash)
+          rel.right = {new_right_name => rel.right }
+        end
+
+        rel.left.name = rel.left.relation.name.to_sym
+        rel.left.relation.name = @scope.klass.table_name
+      end
+
+      def assoc_from_related_table(rel)
+        @scope.klass.reflect_on_association(rel.left.relation.name.to_sym) ||
+          @scope.klass.reflect_on_association(rel.left.relation.name.singularize.to_sym)
+      end
+
+      def substitute_comparisons(opts, rest, arel_node_class, method)
+        build_where_chain(opts, rest) do |rel|
+          case rel
+          when Arel::Nodes::In, Arel::Nodes::Equality
+            arel_node_class.new(rel.left, rel.right)
+          else
+            raise ArgumentError, "Invalid argument for .where.#{method}(), got #{rel.class}"
+          end
+        end
+      end
+
+      def equality_to_function(function_name, opts, rest)
+        build_where_chain(opts, rest) do |rel|
+          case rel
+          when Arel::Nodes::Equality
+            Arel::Nodes::Equality.new(rel.right, Arel::Nodes::NamedFunction.new(function_name, [rel.left]))
+          else
+            raise ArgumentError, "Invalid argument for .where.#{function_name.downcase}(), got #{rel.class}"
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/postgres_ext/active_record/relation/query_methods/with_chain.rb
+++ b/lib/postgres_ext/active_record/relation/query_methods/with_chain.rb
@@ -1,0 +1,18 @@
+module ActiveRecord
+  module QueryMethods
+    # WithChain objects act as placeholder for queries in which #with does not have any parameter.
+    # In this case, #with must be chained with #recursive to return a new relation.
+    class WithChain
+      def initialize(scope)
+        @scope = scope
+      end
+
+      # Returns a new relation expressing WITH RECURSIVE
+      def recursive(*args)
+        @scope.with_values += args
+        @scope.recursive_value = true
+        @scope
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refactor to remove deprecation warnings in Rails 5 about `alias_method_chain`.

I tried to keep the functionality alive, but I'm not super confident here, so I would appreciate a review.